### PR TITLE
Fix varargs warnings

### DIFF
--- a/src/com/webcodepro/applecommander/ui/AppleCommander.java
+++ b/src/com/webcodepro/applecommander/ui/AppleCommander.java
@@ -85,8 +85,8 @@ public class AppleCommander {
 					"com.webcodepro.applecommander.ui.swt.SwtAppleCommander"); //$NON-NLS-1$
 				Object object = swtAppleCommander.newInstance();
 				Method launchMethod = swtAppleCommander.
-					getMethod("launch", null); //$NON-NLS-1$
-				launchMethod.invoke(object, null);
+					getMethod("launch", (Class[])null); //$NON-NLS-1$
+				launchMethod.invoke(object, (Object[])null);
 			} catch (ClassNotFoundException e) {
 				e.printStackTrace();
 			} catch (SecurityException e) {
@@ -139,8 +139,8 @@ public class AppleCommander {
 					"com.webcodepro.applecommander.ui.swing.SwingAppleCommander"); //$NON-NLS-1$
 				Object object = swtAppleCommander.newInstance();
 				Method launchMethod = swtAppleCommander.
-					getMethod("launch", null); //$NON-NLS-1$
-				launchMethod.invoke(object, null);
+					getMethod("launch", (Class[])null); //$NON-NLS-1$
+				launchMethod.invoke(object, (Object[])null);
 			} catch (ClassNotFoundException e) {
 				e.printStackTrace();
 			} catch (SecurityException e) {


### PR DESCRIPTION
Javac cannot tell if the getMethod and launchMethod uses here are
being done with varargs or not, so we need explicit casts to silence the
warning.

This leaves warnings about a number of "unsafe" operations that still need to be fixed which require -Xlint:unchecked to be added as a compilerarg, but these were low-hanging fruit.  :)