### PR TITLE
Remove -Xlint:unchecked warnings

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -87,6 +87,7 @@
 		<javac srcdir="${source}" destdir="${classes}" classpath="${swtjar}">
 			<include name="**/*.java"/>
 			<exclude name="**/*Test.java"/>
+			<compilerarg value="-Xlint:unchecked"/>
 		</javac>
 		<jar jarfile="${guijar}" manifest="build/manifest.mf">
 			<fileset dir="${classes}"/>
@@ -107,6 +108,7 @@
 		<javac srcdir="${source}" destdir="${classes}" >
 			<include name="**/*.java"/>
 			<exclude name="**/*Test.java"/>
+			<compilerarg value="-Xlint:unchecked"/>
 			<compilerarg value="-XDignore.symbol.file"/>
 		</javac>
 		<jar jarfile="${cmdjar}" manifest="build/ac.mf">

--- a/src/com/webcodepro/applecommander/compiler/ApplesoftCompiler.java
+++ b/src/com/webcodepro/applecommander/compiler/ApplesoftCompiler.java
@@ -72,25 +72,25 @@ public class ApplesoftCompiler implements ApplesoftTokens {
 	 * by the compiled program.  This map is keyed by the name of the
 	 * address and the value is the address.
 	 */
-	private Map knownAddresses = new HashMap();
+	private Map<String,String> knownAddresses = new HashMap<>();
 	/**
 	 * Lists the names of all addresses used by the compiled program.
 	 * To identify the value, use the knownAddresses map.
 	 */
-	private List usedAddresses = new ArrayList();
+	private List<String> usedAddresses = new ArrayList<>();
 	/**
 	 * Contains a list of all variables declared or used by the
 	 * program.
 	 */
-	private List variables = new ArrayList();
+	private List<Variable> variables = new ArrayList<>();
 	/**
 	 * Dynamically created map of commands to Methods.
 	 */
-	private Map commandMethods = new HashMap();
+	private Map<String,Method> commandMethods = new HashMap<>();
 	/**
 	 * Track FOR loop variables.
 	 */
-	private Stack loopVariables = new Stack();
+	private Stack<String> loopVariables = new Stack<>();
 	/**
 	 * Indicates integer math operations only.
 	 */

--- a/src/com/webcodepro/applecommander/storage/DirectoryEntry.java
+++ b/src/com/webcodepro/applecommander/storage/DirectoryEntry.java
@@ -37,7 +37,7 @@ public interface DirectoryEntry {
 	 * return value should always be a list - a directory
 	 * with 0 entries returns an empty list.
 	 */
-	public List getFiles();
+	public List<FileEntry> getFiles();
 
 	/**
 	 * Create a new FileEntry.

--- a/src/com/webcodepro/applecommander/storage/FileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/FileEntry.java
@@ -84,7 +84,7 @@ public interface FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode);
+	public List<String> getFileColumnData(int displayMode);
 	
 	/**
 	 * Get file data.  This handles any operating-system specific issues.

--- a/src/com/webcodepro/applecommander/storage/FileEntryComparator.java
+++ b/src/com/webcodepro/applecommander/storage/FileEntryComparator.java
@@ -29,7 +29,7 @@ import java.util.Comparator;
  * Date created: Oct 27, 2002 8:24:39 PM
  * @author Rob Greene
  */
-public class FileEntryComparator implements Comparator {
+public class FileEntryComparator implements Comparator<FileEntry> {
 	private int columnIndex;
 	private int displayMode;
 	
@@ -45,11 +45,12 @@ public class FileEntryComparator implements Comparator {
 	 * Compare two FileEntry objects.
 	 * @see java.util.Comparator#compare(Object, Object)
 	 */
-	public int compare(Object o1, Object o2) {
+	public int compare(FileEntry o1, FileEntry o2) {
+		// FIXME?: This safety check is safe to remove now?
 		if (!(o1 instanceof FileEntry) || !(o2 instanceof FileEntry)) {
 			return 0;
 		}
-		
+
 		if (o1 == null || o2 == null) {
 			return ((o1 == null) ? -1 : 0) + ((o2 == null) ? 1 : 0);
 		}

--- a/src/com/webcodepro/applecommander/storage/FormattedDisk.java
+++ b/src/com/webcodepro/applecommander/storage/FormattedDisk.java
@@ -185,8 +185,8 @@ public abstract class FormattedDisk extends Disk implements DirectoryEntry {
 	 * each disk format can build this as appropriate.  Each subclass should
 	 * override this method and add its own detail.
 	 */
-	public List getDiskInformation() {
-		List list = new ArrayList();
+	public List<DiskInformation> getDiskInformation() {
+		List<DiskInformation> list = new ArrayList<>();
 		list.add(new DiskInformation(textBundle.get("FormattedDisk.FileName"), getFilename())); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("FormattedDisk.DiskName"), getDiskName())); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("FormattedDisk.PhysicalSizeInBytes"), getPhysicalSize())); //$NON-NLS-1$
@@ -204,8 +204,8 @@ public abstract class FormattedDisk extends Disk implements DirectoryEntry {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		list.add(new FileColumnHeader(textBundle
 				.get("Name"), 30, FileColumnHeader.ALIGN_LEFT)); //$NON-NLS-1$
 		list.add(new FileColumnHeader(textBundle

--- a/src/com/webcodepro/applecommander/storage/filters/GraphicsFileFilter.java
+++ b/src/com/webcodepro/applecommander/storage/filters/GraphicsFileFilter.java
@@ -413,7 +413,7 @@ public class GraphicsFileFilter implements FileFilter {
 	 * @see <a href="http://web.pdx.edu/~heiss/technotes/ftyp/ft.about.html">File Types</a>
 	 */
 	public AppleImage[] buildQuickDraw2Icons(FileEntry fileEntry) {
-		List icons = new ArrayList();
+		List<AppleImage> icons = new ArrayList<>();
 		int offset = 26;	// skip file header
 		byte[] filedata = fileEntry.getFileData();
 		while (offset < filedata.length) {

--- a/src/com/webcodepro/applecommander/storage/filters/imagehandlers/AppleImage.java
+++ b/src/com/webcodepro/applecommander/storage/filters/imagehandlers/AppleImage.java
@@ -49,17 +49,17 @@ public abstract class AppleImage {
 	public static AppleImage create(int width, int height) {
 		String[] classes = {
 			"ImageIoImage", "SunJpegImage", "SwtImage" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		Class[] constructorArgClasses = new Class[] {
-			int.class, int.class };
+		Class<?> constructorArgType = AppleImage.class;
+		Class<?>[] constructorArgClasses = new Class[] { AppleImage.class };
 		Object[] constructorArgs = new Object[] {
 			new Integer(width), new Integer(height) };
 		for (int i=0; i<classes.length; i++) {
 			try {
-				Class appleImageClass = Class.forName(
+				Class<?> appleImageClass = Class.forName(
 					"com.webcodepro.applecommander.storage.filters.imagehandlers."  //$NON-NLS-1$
 					+ classes[i]);
-				Constructor constructor = 
-					appleImageClass.getConstructor(constructorArgClasses);
+				Constructor constructor =
+					constructorArgType.getConstructor(constructorArgClasses);
 				AppleImage appleImage = (AppleImage) 
 					constructor.newInstance(constructorArgs);
 				return appleImage;

--- a/src/com/webcodepro/applecommander/storage/os/cpm/CpmFileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/cpm/CpmFileEntry.java
@@ -98,7 +98,7 @@ public class CpmFileEntry implements FileEntry {
 	/**
 	 * The offset(s) into the block that the FileEntry is at.
 	 */
-	private List offsets = new ArrayList();
+	private List<Integer> offsets = new ArrayList<>();
 	
 	/**
 	 * Construct a CP/M file entry.
@@ -374,10 +374,10 @@ public class CpmFileEntry implements FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode) {
+	public List<String> getFileColumnData(int displayMode) {
 		NumberFormat numberFormat = NumberFormat.getNumberInstance();
 
-		List list = new ArrayList();
+		List<String> list = new ArrayList<>();
 		switch (displayMode) {
 			case FormattedDisk.FILE_DISPLAY_NATIVE:
 				list.add(getFilename());

--- a/src/com/webcodepro/applecommander/storage/os/cpm/CpmFormatDisk.java
+++ b/src/com/webcodepro/applecommander/storage/os/cpm/CpmFormatDisk.java
@@ -152,7 +152,7 @@ public class CpmFormatDisk extends FormattedDisk {
 	 * Compute the number of CP/M blocks that are currently used.
 	 */
 	public int getBlocksUsed() {
-		List files = getFiles();
+		List<FileEntry> files = getFiles();
 		int blocksUsed = 0;
 		for (int i=0; i<files.size(); i++) {
 			CpmFileEntry fileEntry = (CpmFileEntry) files.get(i);
@@ -192,7 +192,7 @@ public class CpmFormatDisk extends FormattedDisk {
 			usage[i] = true;
 		}
 		// fill in space used by files
-		List files = getFiles();
+		List<FileEntry> files = getFiles();
 		for (int i=0; i<files.size(); i++) {
 			CpmFileEntry fileEntry = (CpmFileEntry) files.get(i);
 			int[] allocation = fileEntry.getAllocations();
@@ -379,9 +379,9 @@ public class CpmFormatDisk extends FormattedDisk {
 	 * Answer with a list of file entries.
 	 * @see com.webcodepro.applecommander.storage.DirectoryEntry#getFiles()
 	 */
-	public List getFiles() {
-		List files = new ArrayList();
-		Map index = new HashMap();
+	public List<FileEntry> getFiles() {
+		List<FileEntry> files = new ArrayList<>();
+		Map<String,CpmFileEntry> index = new HashMap<>();
 		for (int i=0; i<64; i++) {
 			int offset = i*CpmFileEntry.ENTRY_LENGTH;
 			CpmFileEntry fileEntry = new CpmFileEntry(this, offset);
@@ -473,8 +473,8 @@ public class CpmFormatDisk extends FormattedDisk {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		switch (displayMode) {
 			case FILE_DISPLAY_NATIVE:
 				list.add(new FileColumnHeader(textBundle.get("Name"), 8, //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/storage/os/dos33/DosFileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/dos33/DosFileEntry.java
@@ -263,10 +263,10 @@ public class DosFileEntry implements FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode) {
+	public List<String> getFileColumnData(int displayMode) {
 		NumberFormat numberFormat = NumberFormat.getNumberInstance();
 
-		List list = new ArrayList();
+		List<String> list = new ArrayList<>();
 		switch (displayMode) {
 			case FormattedDisk.FILE_DISPLAY_NATIVE:
 				list.add(isLocked() ? "*" : " "); //$NON-NLS-1$ //$NON-NLS-2$

--- a/src/com/webcodepro/applecommander/storage/os/dos33/DosFormatDisk.java
+++ b/src/com/webcodepro/applecommander/storage/os/dos33/DosFormatDisk.java
@@ -134,8 +134,8 @@ public class DosFormatDisk extends FormattedDisk {
 	 * Retrieve a list of files.
 	 * @see com.webcodepro.applecommander.storage.FormattedDisk#getFiles()
 	 */
-	public List getFiles() {
-		List list = new ArrayList();
+	public List<FileEntry> getFiles() {
+		List<FileEntry> list = new ArrayList<>();
 		byte[] vtoc = readVtoc();
 		int track = AppleUtil.getUnsignedByte(vtoc[1]);
 		int sector = AppleUtil.getUnsignedByte(vtoc[2]);
@@ -319,8 +319,8 @@ public class DosFormatDisk extends FormattedDisk {
 	/**
 	 * Get DOS-specific disk information.
 	 */
-	public List getDiskInformation() {
-		List list = super.getDiskInformation();
+	public List<DiskInformation> getDiskInformation() {
+		List<DiskInformation> list = super.getDiskInformation();
 		list.add(new DiskInformation(textBundle.get("DosFormatDisk.TotalSectors"), getTotalSectors())); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("DosFormatDisk.FreeSectors"), getFreeSectors())); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("DosFormatDisk.UsedSectors"), getUsedSectors())); //$NON-NLS-1$
@@ -333,8 +333,8 @@ public class DosFormatDisk extends FormattedDisk {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		switch (displayMode) {
 			case FILE_DISPLAY_NATIVE:
 				list.add(new FileColumnHeader(" ", 1, FileColumnHeader.ALIGN_CENTER)); //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/storage/os/gutenberg/GutenbergFileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/gutenberg/GutenbergFileEntry.java
@@ -209,9 +209,9 @@ public class GutenbergFileEntry implements FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode) {
+	public List<String> getFileColumnData(int displayMode) {
 		NumberFormat numberFormat = NumberFormat.getNumberInstance();
-		List list = new ArrayList();
+		List<String> list = new ArrayList<>();
 		switch (displayMode) {
 			case FormattedDisk.FILE_DISPLAY_NATIVE:
 				list.add(isLocked() ? "*" : " "); //$NON-NLS-1$ //$NON-NLS-2$

--- a/src/com/webcodepro/applecommander/storage/os/gutenberg/GutenbergFormatDisk.java
+++ b/src/com/webcodepro/applecommander/storage/os/gutenberg/GutenbergFormatDisk.java
@@ -133,8 +133,8 @@ public class GutenbergFormatDisk extends FormattedDisk {
 	 * Retrieve a list of files.
 	 * @see com.webcodepro.applecommander.storage.FormattedDisk#getFiles()
 	 */
-	public List getFiles() {
-		List list = new ArrayList();
+	public List<FileEntry> getFiles() {
+		List<FileEntry> list = new ArrayList<>();
 		int track = CATALOG_TRACK;
 		int sector = VTOC_SECTOR;
 		while (track < 40) { // iterate through all catalog sectors
@@ -309,8 +309,8 @@ public class GutenbergFormatDisk extends FormattedDisk {
 	/**
 	 * Get WP-specific disk information.
 	 */
-	public List getDiskInformation() {
-		List list = super.getDiskInformation();
+	public List<DiskInformation> getDiskInformation() {
+		List<DiskInformation> list = super.getDiskInformation();
 		return list;
 	}
 
@@ -318,8 +318,8 @@ public class GutenbergFormatDisk extends FormattedDisk {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		switch (displayMode) {
 			case FILE_DISPLAY_NATIVE:
 				list.add(new FileColumnHeader(" ", 1, FileColumnHeader.ALIGN_CENTER)); //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/storage/os/nakedos/NakedosFileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/nakedos/NakedosFileEntry.java
@@ -154,9 +154,9 @@ public class NakedosFileEntry implements FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode) {
+	public List<String> getFileColumnData(int displayMode) {
 		NumberFormat numberFormat = NumberFormat.getNumberInstance();
-		List list = new ArrayList();
+		List<String> list = new ArrayList<>();
 		switch (displayMode) {
 			case FormattedDisk.FILE_DISPLAY_NATIVE:
 				list.add(isLocked() ? "*" : " "); //$NON-NLS-1$ //$NON-NLS-2$

--- a/src/com/webcodepro/applecommander/storage/os/nakedos/NakedosFormatDisk.java
+++ b/src/com/webcodepro/applecommander/storage/os/nakedos/NakedosFormatDisk.java
@@ -138,8 +138,8 @@ public class NakedosFormatDisk extends FormattedDisk {
 	 * Retrieve a list of files.
 	 * @see com.webcodepro.applecommander.storage.FormattedDisk#getFiles()
 	 */
-	public List getFiles() {
-		ArrayList list = new ArrayList();
+	public List<FileEntry> getFiles() {
+		ArrayList<FileEntry> list = new ArrayList<>();
 		int totalUsed = 0;
 		int i;
 		int[] fileSizes = new int[256];
@@ -310,9 +310,9 @@ public class NakedosFormatDisk extends FormattedDisk {
 	/**
 	 * Get WP-specific disk information.
 	 */
-	public List getDiskInformation() {
+	public List<DiskInformation> getDiskInformation() {
 		getFiles();
-		List list = super.getDiskInformation();
+		List<DiskInformation> list = super.getDiskInformation();
 		return list;
 	}
 
@@ -320,8 +320,8 @@ public class NakedosFormatDisk extends FormattedDisk {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		switch (displayMode) {
 			case FILE_DISPLAY_NATIVE:
 				list.add(new FileColumnHeader(" ", 1, FileColumnHeader.ALIGN_CENTER)); //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/storage/os/pascal/PascalFileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/pascal/PascalFileEntry.java
@@ -203,7 +203,7 @@ public class PascalFileEntry implements FileEntry {
 	 * Retrieve the list of files in this directory.
 	 * Always returns null, as Pascal does not support directories.
 	 */
-	public List getFiles() {
+	public List<PascalFileEntry> getFiles() {
 		return null;
 	}
 
@@ -223,7 +223,7 @@ public class PascalFileEntry implements FileEntry {
 	public void delete() {
 		int index = 0;
 		String dname = this.getFilename();
-		List dir = disk.getDirectory();
+		List<PascalFileEntry> dir = disk.getDirectory();
 		int count = dir.size();
 		// find the index of the matching entry
 		for (int i = 1; i < count; i++) {
@@ -261,12 +261,12 @@ public class PascalFileEntry implements FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode) {
+	public List<String> getFileColumnData(int displayMode) {
 		NumberFormat numberFormat = NumberFormat.getNumberInstance();
 		SimpleDateFormat dateFormat = new SimpleDateFormat(
 				textBundle.get("PascalFileEntry.PascalDateFormat")); //$NON-NLS-1$
 
-		List list = new ArrayList();
+		List<String> list = new ArrayList<>();
 		switch (displayMode) {
 			case FormattedDisk.FILE_DISPLAY_NATIVE:
 				list.add(dateFormat.format(getModificationDate()));
@@ -344,7 +344,7 @@ public class PascalFileEntry implements FileEntry {
 	 */
 	private void storageError(String s) throws DiskFullException {
 		if (this.index > 0) {
-			List dir = disk.getDirectory();
+			List<PascalFileEntry> dir = disk.getDirectory();
 			int count = dir.size();
 			dir.remove(this.index);
 			PascalFileEntry volEntry = (PascalFileEntry) dir.get(0);
@@ -452,7 +452,7 @@ public class PascalFileEntry implements FileEntry {
 		}
 		// update this directory entry
 		if (this.index > 0) {
-			List dir = disk.getDirectory();
+			List<PascalFileEntry> dir = disk.getDirectory();
 			dir.set(this.index, this);
 			disk.putDirectory(dir);
 		}

--- a/src/com/webcodepro/applecommander/storage/os/pascal/PascalFormatDisk.java
+++ b/src/com/webcodepro/applecommander/storage/os/pascal/PascalFormatDisk.java
@@ -139,8 +139,8 @@ public class PascalFormatDisk extends FormattedDisk {
 	 * Retrieve a list of files.
 	 * @see com.webcodepro.applecommander.storage.FormattedDisk#getFiles()
 	 */
-	public List getFiles() {
-		List list = new ArrayList();
+	public List<FileEntry> getFiles() {
+		List<FileEntry> list = new ArrayList<>();
 		byte[] directory = readDirectory();
 		// process directory blocks:
 		int entrySize = ENTRY_SIZE;
@@ -158,8 +158,8 @@ public class PascalFormatDisk extends FormattedDisk {
  	/**
 	 * Retrieve the entire directory.
 	 */
-	public List getDirectory() {
-		List list = new ArrayList();
+	public List<PascalFileEntry> getDirectory() {
+		List<PascalFileEntry> list = new ArrayList<>();
 		byte[] directory = readDirectory();
 		int count = AppleUtil.getWordValue(directory, 16);
 		int offset = 0;
@@ -194,7 +194,7 @@ public class PascalFormatDisk extends FormattedDisk {
 		// find index of largest free space
 		int count = 0; int index = 0; int max = 0;
 		int last = 0; int first = 0; int free = 0;
-		List dir = getDirectory();
+		List<PascalFileEntry> dir = getDirectory();
 		count = dir.size();
 		for (int i = 1; i < count; i++) {
 			last = ((PascalFileEntry) dir.get(i - 1)).getLastBlock();
@@ -432,8 +432,8 @@ public class PascalFormatDisk extends FormattedDisk {
 	/**
 	 * Get Pascal-specific disk information.
 	 */
-	public List getDiskInformation() {
-		List list = super.getDiskInformation();
+	public List<DiskInformation> getDiskInformation() {
+		List<DiskInformation> list = super.getDiskInformation();
 		list.add(new DiskInformation(textBundle.get("TotalBlocks"), getBlocksOnDisk())); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("FreeBlocks"), getFreeBlocks())); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("UsedBlocks"), getUsedBlocks())); //$NON-NLS-1$
@@ -452,8 +452,8 @@ public class PascalFormatDisk extends FormattedDisk {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		switch (displayMode) {
 			case FILE_DISPLAY_NATIVE:
 				list.add(new FileColumnHeader(textBundle.get("Modified"), 8, //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/storage/os/prodos/ProdosDirectoryEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/prodos/ProdosDirectoryEntry.java
@@ -61,7 +61,7 @@ public class ProdosDirectoryEntry extends ProdosFileEntry implements DirectoryEn
 	 * return value should always be a list - a directory
 	 * with 0 entries returns an empty list.
 	 */
-	public List getFiles() {
+	public List<FileEntry> getFiles() {
 		return getDisk().getFiles(getSubdirectoryHeader().getFileEntryBlock());
 	}
 

--- a/src/com/webcodepro/applecommander/storage/os/prodos/ProdosFileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/prodos/ProdosFileEntry.java
@@ -397,12 +397,12 @@ public class ProdosFileEntry extends ProdosCommonEntry implements FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode) {
+	public List<String> getFileColumnData(int displayMode) {
 		NumberFormat numberFormat = NumberFormat.getNumberInstance();
 		SimpleDateFormat dateFormat = new SimpleDateFormat(
 				textBundle.get("DateFormat")); //$NON-NLS-1$
 
-		List list = new ArrayList();
+		List<String> list = new ArrayList<>();
 		switch (displayMode) {
 			case FormattedDisk.FILE_DISPLAY_NATIVE:
 				list.add(isLocked() ? "*" : " "); //$NON-NLS-1$ //$NON-NLS-2$

--- a/src/com/webcodepro/applecommander/storage/os/prodos/ProdosFormatDisk.java
+++ b/src/com/webcodepro/applecommander/storage/os/prodos/ProdosFormatDisk.java
@@ -257,7 +257,7 @@ public class ProdosFormatDisk extends FormattedDisk {
 	 * Retrieve a list of files.
 	 * @see com.webcodepro.applecommander.storage.FormattedDisk#getFiles()
 	 */
-	public List getFiles() {
+	public List<FileEntry> getFiles() {
 		return getFiles(VOLUME_DIRECTORY_BLOCK);
 	}
 
@@ -265,8 +265,8 @@ public class ProdosFormatDisk extends FormattedDisk {
 	 * Build a list of files, starting in the given block number.
 	 * This works for the master as well as the subdirectories.
 	 */		
-	protected List getFiles(int blockNumber) {
-		List files = new ArrayList();
+	protected List<FileEntry> getFiles(int blockNumber) {
+		List<FileEntry> files = new ArrayList<>();
 		while (blockNumber != 0) {
 			byte[] block = readBlock(blockNumber);
 			int offset = 4;
@@ -400,8 +400,8 @@ public class ProdosFormatDisk extends FormattedDisk {
 	/**
 	 * Get Pascal-specific disk information.
 	 */
-	public List getDiskInformation() {
-		List list = super.getDiskInformation();
+	public List<DiskInformation> getDiskInformation() {
+		List<DiskInformation> list = super.getDiskInformation();
 		list.add(new DiskInformation(textBundle.get("TotalBlocks"),  //$NON-NLS-1$
 				volumeHeader.getTotalBlocks()));
 		list.add(new DiskInformation(textBundle.get("FreeBlocks"),  //$NON-NLS-1$
@@ -429,8 +429,8 @@ public class ProdosFormatDisk extends FormattedDisk {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		switch (displayMode) {
 			case FILE_DISPLAY_NATIVE:
 				list.add(new FileColumnHeader(" ", 1, FileColumnHeader.ALIGN_CENTER)); //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/storage/os/rdos/RdosFileEntry.java
+++ b/src/com/webcodepro/applecommander/storage/os/rdos/RdosFileEntry.java
@@ -157,7 +157,7 @@ public class RdosFileEntry implements FileEntry {
 	 * Retrieve the list of files in this directory.
 	 * Since RDOS does not support directories, this will always return null.
 	 */
-	public List getFiles() {
+	public List<RdosFileEntry> getFiles() {
 		return null;
 	}
 	
@@ -180,10 +180,10 @@ public class RdosFileEntry implements FileEntry {
 	 * This default implementation is intended only for standard mode.
 	 * displayMode is specified in FormattedDisk.
 	 */
-	public List getFileColumnData(int displayMode) {
+	public List<String> getFileColumnData(int displayMode) {
 		NumberFormat numberFormat = NumberFormat.getNumberInstance();
 
-		List list = new ArrayList();
+		List<String> list = new ArrayList<>();
 		switch (displayMode) {
 			case FormattedDisk.FILE_DISPLAY_NATIVE:
 				list.add(getFiletype());

--- a/src/com/webcodepro/applecommander/storage/os/rdos/RdosFormatDisk.java
+++ b/src/com/webcodepro/applecommander/storage/os/rdos/RdosFormatDisk.java
@@ -182,8 +182,8 @@ public class RdosFormatDisk extends FormattedDisk {
 	/**
 	 * Retrieve a list of files.
 	 */
-	public List getFiles() {
-		List files = new ArrayList();
+	public List<FileEntry> getFiles() {
+		List<FileEntry> files = new ArrayList<>();
 		for (int b=13; b<23; b++) {
 			byte[] data = readRdosBlock(b);
 			for (int i=0; i<data.length; i+= ENTRY_LENGTH) {
@@ -297,8 +297,8 @@ public class RdosFormatDisk extends FormattedDisk {
 	/**
 	 * Get Pascal-specific disk information.
 	 */
-	public List getDiskInformation() {
-		List list = super.getDiskInformation();
+	public List<DiskInformation> getDiskInformation() {
+		List<DiskInformation> list = super.getDiskInformation();
 		list.add(new DiskInformation(textBundle.get("TotalBlocks"), BLOCKS_ON_DISK)); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("FreeBlocks"), getFreeBlocks())); //$NON-NLS-1$
 		list.add(new DiskInformation(textBundle.get("UsedBlocks"), getUsedBlocks())); //$NON-NLS-1$
@@ -309,8 +309,8 @@ public class RdosFormatDisk extends FormattedDisk {
 	 * Get the standard file column header information.
 	 * This default implementation is intended only for standard mode.
 	 */
-	public List getFileColumnHeaders(int displayMode) {
-		List list = new ArrayList();
+	public List<FileColumnHeader> getFileColumnHeaders(int displayMode) {
+		List<FileColumnHeader> list = new ArrayList<>();
 		switch (displayMode) {
 			case FILE_DISPLAY_NATIVE:
 				list.add(new FileColumnHeader(textBundle.get("Type"), 1, FileColumnHeader.ALIGN_CENTER)); //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/ui/AppleCommander.java
+++ b/src/com/webcodepro/applecommander/ui/AppleCommander.java
@@ -79,14 +79,14 @@ public class AppleCommander {
 	 * command-line version.
 	 */
 	protected static void launchSwtAppleCommander(String[] args) {
-			Class swtAppleCommander;
+			Class<?> swtAppleCommander;
 			try {
 				swtAppleCommander =	Class.forName(
 					"com.webcodepro.applecommander.ui.swt.SwtAppleCommander"); //$NON-NLS-1$
 				Object object = swtAppleCommander.newInstance();
 				Method launchMethod = swtAppleCommander.
-					getMethod("launch", (Class[])null); //$NON-NLS-1$
-				launchMethod.invoke(object, (Object[])null);
+					getMethod("launch", (Class[]) null); //$NON-NLS-1$
+				launchMethod.invoke(object, (Object[]) null);
 			} catch (ClassNotFoundException e) {
 				e.printStackTrace();
 			} catch (SecurityException e) {
@@ -133,14 +133,14 @@ public class AppleCommander {
 	 * command-line version.
 	 */
 	protected static void launchSwingAppleCommander(String[] args) {
-			Class swtAppleCommander;
+			Class<?> swtAppleCommander;
 			try {
 				swtAppleCommander =	Class.forName(
 					"com.webcodepro.applecommander.ui.swing.SwingAppleCommander"); //$NON-NLS-1$
 				Object object = swtAppleCommander.newInstance();
 				Method launchMethod = swtAppleCommander.
-					getMethod("launch", (Class[])null); //$NON-NLS-1$
-				launchMethod.invoke(object, (Object[])null);
+					getMethod("launch", (Class[]) null); //$NON-NLS-1$
+				launchMethod.invoke(object, (Object[]) null);
 			} catch (ClassNotFoundException e) {
 				e.printStackTrace();
 			} catch (SecurityException e) {

--- a/src/com/webcodepro/applecommander/ui/swt/DiskExplorerTab.java
+++ b/src/com/webcodepro/applecommander/ui/swt/DiskExplorerTab.java
@@ -158,8 +158,8 @@ public class DiskExplorerTab {
 
 	private int currentFormat = FormattedDisk.FILE_DISPLAY_STANDARD;
 	private boolean formatChanged;
-	private List currentFileList;
-	private Map columnWidths = new HashMap();
+	private List<FileEntry> currentFileList;
+	private Map<Integer,int[]> columnWidths = new HashMap<>();
 	private boolean showDeletedFiles;
 
 	/**
@@ -846,7 +846,7 @@ public class DiskExplorerTab {
 	/**
 	 * Display files in the fileTable.
 	 */
-	protected void fillFileTable(List fileList) {
+	protected void fillFileTable(List<FileEntry> fileList) {
 		int[] weights = sashForm.getWeights();
 
 		if (formatChanged) {
@@ -1407,7 +1407,7 @@ public class DiskExplorerTab {
 		TreeItem selection = directoryTree.getSelection()[0];
 		Object data = selection.getData();
 		DirectoryEntry directory = (DirectoryEntry) data;
-		List fileList = directory.getFiles();
+		List<FileEntry> fileList = directory.getFiles();
 		
 		formatChanged = (currentFormat != newFormat);
 		if (formatChanged || !fileList.equals(currentFileList)) {
@@ -2017,7 +2017,7 @@ public class DiskExplorerTab {
 		return viewFileItem;
 	}
 	
-	protected List getCurrentFileList() {
+	protected List<FileEntry> getCurrentFileList() {
 		return currentFileList;
 	}
 	

--- a/src/com/webcodepro/applecommander/ui/swt/FileViewerWindow.java
+++ b/src/com/webcodepro/applecommander/ui/swt/FileViewerWindow.java
@@ -99,7 +99,7 @@ public class FileViewerWindow {
 	private Color green;
 	
 	private ContentTypeAdapter contentTypeAdapter;
-	private Map nativeFilterAdapterMap;
+	private Map<Class<?>,FilterAdapter> nativeFilterAdapterMap;
 	private FilterAdapter nativeFilterAdapter;
 	private FilterAdapter hexFilterAdapter;
 	private FilterAdapter rawDumpFilterAdapter;
@@ -165,7 +165,7 @@ public class FileViewerWindow {
 	 * Setup all possible specialized FilterAdapters.
 	 */	
 	protected void createFilterAdapterMap() {
-		nativeFilterAdapterMap = new HashMap();
+		nativeFilterAdapterMap = new HashMap<>();
 		
 		nativeFilterAdapterMap.put(ApplesoftFileFilter.class, 
 			new ApplesoftFilterAdapter(this, textBundle.get("FileViewerWindow.ApplesoftButton"),  //$NON-NLS-1$

--- a/src/com/webcodepro/applecommander/ui/swt/util/ImageManager.java
+++ b/src/com/webcodepro/applecommander/ui/swt/util/ImageManager.java
@@ -75,7 +75,7 @@ public class ImageManager {
 	public static final String LOGO_COMPILE_WIZARD = "CompileWizardLogo.gif"; //$NON-NLS-1$
 	public static final String LOGO_COMPARE_IMAGE_WIZARD = "CompareImageWizardLogo.gif"; //$NON-NLS-1$
 	
-	private Map images = new HashMap();
+	private Map<String,Image> images = new HashMap<>();
 	private String[] imageNames = {
 		// Icons:
 		ICON_DISK,					ICON_STANDARD_FILE_VIEW,

--- a/src/com/webcodepro/applecommander/ui/swt/wizard/Wizard.java
+++ b/src/com/webcodepro/applecommander/ui/swt/wizard/Wizard.java
@@ -48,7 +48,7 @@ public abstract class Wizard {
 	private Shell dialog;
 	private Image logo;
 	private String title;
-	private Stack wizardPanes = new Stack();
+	private Stack<WizardPane> wizardPanes = new Stack<>();
 	private boolean wizardCompleted;
 	private Button backButton;
 	private Button nextButton;
@@ -109,8 +109,8 @@ public abstract class Wizard {
 		backButton.setText(textBundle.get("BackButton")); //$NON-NLS-1$
 		backButton.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				WizardPane current = (WizardPane) getWizardPanes().pop();
-				WizardPane previous = (WizardPane) getWizardPanes().peek();
+				WizardPane current = getWizardPanes().pop();
+				WizardPane previous = getWizardPanes().peek();
 				getBackButton().setEnabled(getWizardPanes().size() > 1);
 				current.dispose();
 				previous.open();
@@ -220,7 +220,7 @@ public abstract class Wizard {
 	/**
 	 * @return Returns the wizardPanes.
 	 */
-	protected Stack getWizardPanes() {
+	protected Stack<WizardPane> getWizardPanes() {
 		return wizardPanes;
 	}
 	/**

--- a/src/com/webcodepro/applecommander/ui/swt/wizard/importfile/ImportWizard.java
+++ b/src/com/webcodepro/applecommander/ui/swt/wizard/importfile/ImportWizard.java
@@ -39,7 +39,7 @@ import com.webcodepro.applecommander.ui.swt.wizard.WizardPane;
  */
 public class ImportWizard extends Wizard {
 	private FormattedDisk disk;
-	private List importSpecifications;
+	private List<ImportSpecification> importSpecifications;
 	/**
 	 * Constructor for ImportWizard.
 	 */
@@ -70,9 +70,9 @@ public class ImportWizard extends Wizard {
 	/**
 	 * Get the list of ImportSpecifications.
 	 */
-	public List getImportSpecifications() {
+	public List<ImportSpecification> getImportSpecifications() {
 		if (importSpecifications == null) {
-			importSpecifications = new ArrayList();
+			importSpecifications = new ArrayList<>();
 		}
 		return importSpecifications;
 	}


### PR DESCRIPTION
Fixed all instances of warnings OpenJDK finds with -Xlint:unchecked.
Merging this will at least result in a dependency on JDK 1.5 or later
that I'm pretty sure of.  But since the only JDKs that are really safe
to use these days are versions 1.8 and 9, that's probably okay.

No promises that this will make modern SWT work or anything, but it's
probably at least a beginnig toward that as well.