### PR TITLE
Add Windows and Linux to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,15 +9,25 @@ apply plugin: 'application'
 mainClassName = 'com.webcodepro.applecommander.ui.AppleCommander'
 
 // Configure build for each supported platform
-def os = System.getProperty("os.name").toLowerCase()
-def arch = System.getProperty("os.arch")
 ext {
+	os = System.getProperty("os.name").toLowerCase()
+	arch = System.getProperty("os.arch").toLowerCase()
+
+	// First let's sanitize arch
+	if (arch.contains("amd64")) {
+		swtArch = "x86_64"
+	} else if (arch.matches("i[3-6]86]")) {
+		swtArch = "x86"
+	} else {
+		swtArch = arch
+	}
+
 	if (os.contains("windows")) {
-		swtGUI = "win32.win32.$arch"
+		swtGUI = "win32.win32.$swtArch"
 	} else if (os.contains("mac os x")) {
-		swtGUI = "cocoa.macosx.$arch"
+		swtGUI = "cocoa.macosx.$swtArch"
 	} else if (os.contains("linux")) {
-		swtGUI = "gtk.linux.$arch"
+		swtGUI = "gtk.linux.$swtArch"
 	} else {
 		throw new GradleException("Don't know how to build for this platform:\n" +
 				"      os = \"$os\"\n" +

--- a/build.gradle
+++ b/build.gradle
@@ -10,34 +10,34 @@ mainClassName = 'com.webcodepro.applecommander.ui.AppleCommander'
 
 // Configure build for each supported platform
 ext {
-	os = System.getProperty("os.name").toLowerCase()
-	arch = System.getProperty("os.arch").toLowerCase()
+    os = System.getProperty("os.name").toLowerCase()
+    arch = System.getProperty("os.arch").toLowerCase()
 
-	// First let's sanitize arch
-	if (arch.contains("amd64")) {
-		swtArch = "x86_64"
-	} else if (arch.matches("i[3-6]86]")) {
-		swtArch = "x86"
-	} else {
-		swtArch = arch
-	}
+    // First let's sanitize arch
+    if (arch.contains("amd64")) {
+        swtArch = "x86_64"
+    } else if (arch.matches("i[3-6]86]")) {
+        swtArch = "x86"
+    } else {
+        swtArch = arch
+    }
 
-	if (os.contains("windows")) {
-		swtGUI = "win32.win32.$swtArch"
-	} else if (os.contains("mac os x")) {
-		swtGUI = "cocoa.macosx.$swtArch"
-	} else if (os.contains("linux")) {
-		swtGUI = "gtk.linux.$swtArch"
-	} else {
-		throw new GradleException("Don't know how to build for this platform:\n" +
-				"      os = \"$os\"\n" +
-				"    arch = \"$arch\"\n\n" +
-				"Edit build.gradle to add support")
-		/* At least you'll need to define swtGUI for your os and
-		 * probably your arch too.  Most SWT backend GUI descriptions
-		 * take the form of <widgetset>.<os-tag>.<arch>.
-		 */
-	}
+    if (os.contains("windows")) {
+        swtGUI = "win32.win32.$swtArch"
+    } else if (os.contains("mac os x")) {
+        swtGUI = "cocoa.macosx.$swtArch"
+    } else if (os.contains("linux")) {
+        swtGUI = "gtk.linux.$swtArch"
+    } else {
+        throw new GradleException("Don't know how to build for this platform:\n" +
+                "      os = \"$os\"\n" +
+                "    arch = \"$arch\"\n\n" +
+                "Edit build.gradle to add support")
+        /* At least you'll need to define swtGUI for your os and
+         * probably your arch too.  Most SWT backend GUI descriptions
+         * take the form of <widgetset>.<os-tag>.<arch>.
+         */
+    }
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,29 @@ apply plugin: 'application'
 // Define the main class for the application
 mainClassName = 'com.webcodepro.applecommander.ui.AppleCommander'
 
+// Configure build for each supported platform
+def os = System.getProperty("os.name").toLowerCase()
+def arch = System.getProperty("os.arch")
+ext {
+	if (os.contains("windows")) {
+		swtGUI = "win32.win32.$arch"
+	} else if (os.contains("mac os x")) {
+		swtGUI = "cocoa.macosx.$arch"
+	} else if (os.contains("linux")) {
+		swtGUI = "gtk.linux.$arch"
+	} else {
+		throw new GradleException("Don't know how to build for this platform:\n" +
+				"      os = \"$os\"\n" +
+				"    arch = \"$arch\"\n\n" +
+				"Edit build.gradle to add support")
+		/* At least you'll need to define swtGUI for your os and
+		 * probably your arch too.  Most SWT backend GUI descriptions
+		 * take the form of <widgetset>.<os-tag>.<arch>.
+		 */
+	}
+}
+
+
 // In this section you declare where to find the dependencies of your project
 repositories {
     mavenCentral()
@@ -17,8 +40,8 @@ repositories {
 }
 
 dependencies {
-    compile "org.eclipse.swt:org.eclipse.swt.cocoa.macosx.x86_64:$swtVersion"
-    
+    compile "org.eclipse.swt:org.eclipse.swt.$swtGUI:$swtVersion"
+
     compileOnly "org.apache.ant:ant:$antVersion"
 
     testCompile "junit:junit:$junitVersion"
@@ -27,7 +50,7 @@ dependencies {
 jar {
     manifest {
         attributes 'Main-Class': "$mainClassName"
-    } 
+    }
     doFirst {
         from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
     }


### PR DESCRIPTION
The additions here are a little on the ugly side, but they do something we didn't have with the ant build: They can support building pretty much anywhere, with any target you configure, and the vast majority of systems out there (Windows, Mac, Linux) running Intel/AMD 32/64 bit CPUs or 32 or 64 bit PowerPC in the case of the mac … they should just work at this point.  I haven't got a VM set up for development to test Windows, but Windows is usually the easy one for Java stuff since Microsoft still supports Windows 3.0 widgets somewhere in Windows 10 most likely.

Now's a good time to ask since source files are moving around: Could we perhaps restructure some source code a bit to/shorten/some/very/deeply/nested/paths/that/probably/dont/need/it?  I blame Sun for this because they started the whole little-endian domain name thing to help ensure namespaces didn't collide.  But even they abandoned it at some point because it was dumb if anybody ever changed websites…  We'll need to maintain a few entry points for things like ADTPro, but not many.

BTW, this actually came up with the SWT GUI for me on Linux.  It has the same problem as SWT on Mac for the FileFilter dialog.