### PR TITLE
AC multi-operation change

### DIFF
--- a/app/ant-ac/src/main/java/com/webcodepro/applecommander/ui/AntTask.java
+++ b/app/ant-ac/src/main/java/com/webcodepro/applecommander/ui/AntTask.java
@@ -119,11 +119,11 @@ public class AntTask extends Task
 				else if (_command.equals("cc65")) 
 				{
 					System.err.println("Note: 'cc65' is deprecated.  Please use 'as' or 'dos' as appropriate."); 
-					com.webcodepro.applecommander.ui.ac.putDOS(_input, _imageName, _fileName, _type);
+					com.webcodepro.applecommander.ui.ac.putDOS(_input, _imageName, _fileName, _type, System.in);
 				}
 				else if (_command.equals("dos")) 
 				{
-					com.webcodepro.applecommander.ui.ac.putDOS(_input, _imageName, _fileName, _type);
+					com.webcodepro.applecommander.ui.ac.putDOS(_input, _imageName, _fileName, _type, System.in);
 				}
 				else {
 					com.webcodepro.applecommander.ui.ac.putAppleSingle(_imageName, _fileName,

--- a/lib/ac-api/src/main/resources/com/webcodepro/applecommander/ui/UiBundle.properties
+++ b/lib/ac-api/src/main/resources/com/webcodepro/applecommander/ui/UiBundle.properties
@@ -104,6 +104,7 @@ CommandLineNoMatchMessage = {0}: No match.
 CommandLineStatus = {0} format; {1} bytes free; {2} bytes used.
 CommandLineHelp = \
     AppleCommander command line options [{0}]:\n\
+    NOTE: <infile> can either be a local file or '-' for STDIN.\n\
     -i       <imagename> [<imagename>] display information about image(s).\n\
     -ls      <imagename> [<imagename>] list brief directory of image(s).\n\
     -l       <imagename> [<imagename>] list directory of image(s).\n\
@@ -117,16 +118,16 @@ CommandLineHelp = \
     -e       <imagename> <filename> [<output>] export file from image to stdout\n         or to an output file.\n\
     -x       <imagename> [<directory>] extract all files from image to directory.\n\
     -g       <imagename> <filename> [<output>] get raw file from image to stdout\n         or to an output file.\n\
-    -p       <imagename> <filename> <type> [[$|0x]<addr>] put stdin\n         in filename on image, using file type and address [0x2000].\n\
-    -pt      <imagename> <filename> put stdin in filename on image\n         defaulting to TXT file type, setting high bit on and replacing\n         newline characters with $8D.\n\
-    -ptx     <imagename> <filename> put stdin in filename on image\n         defaulting to TXT file type, clearing high bit and replacing\n         newline characters with $0D.\n\
+    -p       <imagename> <filename> <type> [[$|0x]<addr>] <infile> put infile\n         as filename on image, using file type and address [0x2000].\n\
+    -pt      <imagename> <filename> <infile> put infile as filename on image\n         defaulting to TXT file type, setting high bit on and replacing\n         newline characters with $8D.\n\
+    -ptx     <imagename> <filename> <infile> put infile as filename on image\n         defaulting to TXT file type, clearing high bit and replacing\n         newline characters with $0D.\n\
     -d       <imagename> <filename> delete file from image.\n\
     -k       <imagename> <filename> lock file on image.\n\
     -u       <imagename> <filename> unlock file on image.\n\
     -n       <imagename> <volname> change volume name (ProDOS or Pascal).\n\
-    -dos     <imagename> <filename> <type> put stdin with DOS header\n         in filename on image, using file type and address from header.\n\
-    -as      <imagename> [<filename>] put stdin with AppleSingle format\n         in filename on image, using file type, address, and (optionally) name\n         from the AppleSingle file.\n\
-    -geos    <imagename> interpret stdin as a GEOS conversion file and\n         place it on image (ProDOS only).\n\
+    -dos     <imagename> <filename> <type> <infile> put infile with DOS header\n         as filename on image, using file type and address from header.\n\
+    -as      <imagename> [<filename>] <infile> put infile with AppleSingle format\n         as filename on image, using file type, address, and (optionally) name\n         from the AppleSingle file.\n\
+    -geos    <imagename> interpret infile as a GEOS conversion file and\n         place it on image (ProDOS only).\n\
     -dos140  <imagename> create a 140K DOS 3.3 image.\n\
     -pro140  <imagename> <volname>\n         create a 140K ProDOS image.\n\
     -pro800  <imagename> <volname> create an 800K ProDOS image.\n\


### PR DESCRIPTION
Changed command line parsing to allow for multiple operations in the same JVM instance. Multiple commands are specified sequentially (e.g. ac.sh -ptx volume.po afile afile.txt -bas volume.po bfile bfile.bas).

This required adding support for several operations to read files instead of STDIN. However, STDIN support remains for those who want to use it, though they need to specify '-' as the file. (e.g. ac.sh -ptx volume.po afile - <afile.txt)

The point of doing this was that I have a .po that I am writing 1000 files to. Doing this file-by-file with the existing ac.sh mechanism takes nearly 6 minutes because of the constant bring-up/tear-down of a JVM. With this change, the same task can be done in under 20 seconds.