### PR TITLE
acx - Imported AppleSingle files are locked

### DIFF
--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/ImportCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/ImportCommand.java
@@ -287,7 +287,7 @@ public class ImportCommand extends ReadWriteDiskCommandOptions {
                 builder.fileData(as.getDataFork());
                 builder.resourceData(Optional.ofNullable(as.getResourceFork()));
                 builder.prodosFiletype(fileType);
-                builder.locked(info.getAccess() == 0xc3);
+                builder.locked((info.getAccess()&0xc2) != 0xc2); //Unlocked if destory, rename and write are all enabled
                 builder.auxiliaryType(info.getAuxType());
                 
                 if (as.getFileDatesInfo() != null) {


### PR DESCRIPTION
When I import an AppleSingle file created by cc65 to a ProDOS image, the imported file `HELLO.AS` is locked as shown below.

```
File: prodos.dsk
Name: /PRODOS1.9/
  PRODOS          SYS      034 08/20/1990 <NO DATE>      16,509
  BASIC.SYSTEM    SYS      021 08/20/1990 <NO DATE>      10,240 A=$2000
  STARTUP         BAS      001 <NO DATE>  <NO DATE>          39 A=$0801
* HELLO.AS        BIN      007 01/14/2023 01/14/2023      2,869
ProDOS format; 107,520 bytes free; 35,840 bytes used.
```

The `handleAppleSingleMode` method sets the Lock flag when `info.getAccess() == 0xc3`. But `0xc3` means the file is unlocked. 

According to ProDOS Technical Reference,

>  If the file is destroy, rename, and write enabled, it is unlocked. 

So, the condition to set the Lock flag should be `(info.getAccess()&0xc2) != 0xc2`.