### PR TITLE
acx - help messages of delete and lock command are wrong

### DIFF
--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/base/ReadWriteDiskCommandWithGlobOptions.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/base/ReadWriteDiskCommandWithGlobOptions.java
@@ -28,25 +28,23 @@ import com.webcodepro.applecommander.util.filestreamer.FileStreamer;
 import com.webcodepro.applecommander.util.filestreamer.FileTuple;
 import com.webcodepro.applecommander.util.filestreamer.TypeOfFile;
 
-import picocli.CommandLine.Parameters;
-
 public abstract class ReadWriteDiskCommandWithGlobOptions extends ReadWriteDiskCommandOptions {
     private static Logger LOG = Logger.getLogger(ReadWriteDiskCommandWithGlobOptions.class.getName());
 
-    @Parameters(arity = "1..*", description = "File glob(s) to unlock (default = '*') - be cautious of quoting!")
-    private List<String> globs = Arrays.asList("*");
+	//Subclasses must declare globs data member and implement getGlobs() method
+	protected abstract List<String> getGlobs();
 
     @Override
     public int handleCommand() throws Exception {
         List<FileTuple> files = FileStreamer.forDisk(disk)
 			        .ignoreErrors(true)
 			        .includeTypeOfFile(TypeOfFile.FILE)
-			        .matchGlobs(globs)
+			        .matchGlobs(this.getGlobs())
 			        .stream()
 			        .collect(Collectors.toList());
 
         if (files.isEmpty()) {
-        	LOG.warning(() -> String.format("No matches found for %s.", String.join(",", globs)));
+        	LOG.warning(() -> String.format("No matches found for %s.", String.join(",", this.getGlobs())));
         } else {
         	files.forEach(this::fileHandler);
         }

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DeleteCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DeleteCommand.java
@@ -20,18 +20,27 @@
 package io.github.applecommander.acx.command;
 
 import java.util.logging.Logger;
+import java.util.Arrays;
+import java.util.List;
 
 import com.webcodepro.applecommander.util.filestreamer.FileTuple;
 
 import io.github.applecommander.acx.base.ReadWriteDiskCommandWithGlobOptions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 @Command(name = "delete", description = "Delete file(s) from a disk image.",
         aliases = { "del", "rm" })
 public class DeleteCommand extends ReadWriteDiskCommandWithGlobOptions {
     private static Logger LOG = Logger.getLogger(DeleteCommand.class.getName());
     
+	@Parameters(arity = "1..*", description = "File glob(s) to delete (default = '*') - be cautious of quoting!")
+    private List<String> globs = Arrays.asList("*");
+	
+	@Override
+	protected List<String> getGlobs(){return globs;}
+	
     @Option(names = { "-f", "--force" }, description = "Force delete locked files.")
     private boolean forceFlag;
 

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/LockCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/LockCommand.java
@@ -20,15 +20,24 @@
 package io.github.applecommander.acx.command;
 
 import java.util.logging.Logger;
+import java.util.Arrays;
+import java.util.List;
 
 import com.webcodepro.applecommander.util.filestreamer.FileTuple;
 
 import io.github.applecommander.acx.base.ReadWriteDiskCommandWithGlobOptions;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
 
 @Command(name = "lock", description = "Lock file(s) on a disk image.")
 public class LockCommand extends ReadWriteDiskCommandWithGlobOptions {
     private static Logger LOG = Logger.getLogger(LockCommand.class.getName());
+
+	@Parameters(arity = "1..*", description = "File glob(s) to lock (default = '*') - be cautious of quoting!")
+    private List<String> globs = Arrays.asList("*");
+	
+	@Override
+	protected List<String> getGlobs(){return globs;}
 
     public void fileHandler(FileTuple tuple) {
     	tuple.fileEntry.setLocked(true);

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/UnlockCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/UnlockCommand.java
@@ -20,17 +20,26 @@
 package io.github.applecommander.acx.command;
 
 import java.util.logging.Logger;
+import java.util.Arrays;
+import java.util.List;
 
 import com.webcodepro.applecommander.util.filestreamer.FileTuple;
 
 import io.github.applecommander.acx.base.ReadWriteDiskCommandWithGlobOptions;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
 
 @Command(name = "unlock", description = "Unlock file(s) on a disk image.")
 public class UnlockCommand extends ReadWriteDiskCommandWithGlobOptions {
     private static Logger LOG = Logger.getLogger(UnlockCommand.class.getName());
-
-    public void fileHandler(FileTuple tuple) {
+	
+	@Parameters(arity = "1..*", description = "File glob(s) to unlock (default = '*') - be cautious of quoting!")
+    private List<String> globs = Arrays.asList("*");
+	
+	@Override
+	protected List<String> getGlobs(){return globs;}
+    
+	public void fileHandler(FileTuple tuple) {
     	tuple.fileEntry.setLocked(false);
     	LOG.info(() -> String.format("File '%s' unlocked.", tuple.fileEntry.getFilename()));
     }


### PR DESCRIPTION
If I get the help message of Delete command by `java -jar AppleCommander-acx-1.8.0.jar delete --help`, I get this message. Note the description of `<globs>`  is `File glob(s) to unlock`.  Lock command has the same problem.

```
Usage: acx delete [-fh] -d=<disk> <globs>...

Delete file(s) from a disk image.

Parameters:
      <globs>...      File glob(s) to unlock (default = '*') - be cautious of
                        quoting!

Options:
  -d, --disk=<disk>   Image to process [$ACX_DISK_NAME].
  -f, --force         Force delete locked files.
  -h, --help          Show help for subcommand.
```

My fix is to move the declaration of `globs` data member from `ReadWriteDiskCommandWithGlobOptions` class to subclasses. Then, the base class access it through a getter method.