### PR TITLE
acx - Display volume name and free/used bytes when listing an empty image

### DIFF
--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/ListCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/ListCommand.java
@@ -73,6 +73,9 @@ public class ListCommand extends ReadOnlyDiskImageCommandOptions {
         ListingStrategy listingStrategy = outputType.create(display);
         
         listingStrategy.first(disk);
+
+        FormattedDisk formattedDisk = disk.getFormattedDisks()[0];
+        listingStrategy.beforeDisk(formattedDisk);
         
         FileStreamer.forDisk(disk)
                     .ignoreErrors(true)
@@ -80,10 +83,10 @@ public class ListCommand extends ReadOnlyDiskImageCommandOptions {
                     .recursive(recursiveFlag)
                     .includeTypeOfFile(typeOfFile.typeOfFile())
                     .matchGlobs(globs)
-                    .beforeDisk(listingStrategy::beforeDisk)
-                    .afterDisk(listingStrategy::afterDisk)
                     .stream()
                     .forEach(listingStrategy::forEach);
+
+        listingStrategy.afterDisk(formattedDisk);
         
         listingStrategy.last(disk);
         


### PR DESCRIPTION
When I use `acx` to list the content of an empty image, the prgram just quits and outputs nothing. The program should display the volume name and free/used bytes information even the image is empty.

My fix is to call `beforeDisk()` and `afterDisk()` methods directly instead of relying `FileStreamer`. Here is the sample output.

```
File: empty.dsk
Name: DISK VOLUME #254
DOS 3.3 format; 135,168 bytes free; 8,192 bytes used.
```