### PR TITLE
acx - Filter out deleted file entries in MkdirCommand

### DIFF
--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/MkdirCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/MkdirCommand.java
@@ -49,6 +49,7 @@ public class MkdirCommand extends ReadWriteDiskCommandOptions {
             final String pathName = formattedDisk.getSuggestedFilename(paths[i]);
             Optional<FileEntry> optEntry = directory.getFiles().stream()
                     .filter(entry -> entry.getFilename().equalsIgnoreCase(pathName))
+                    .filter(entry -> !entry.isDeleted())
                     .findFirst();
             
             if (optEntry.isPresent()) {


### PR DESCRIPTION
If I remove a directory and create it again, I get `Not a directory` error as shown below.

```
$ java -jar acx.jar create -d=test.dsk --prodos
$ java -jar acx.jar mkdir -d=test.dsk testdir
$ java -jar acx.jar rmdir -d=test.dsk testdir
$ java -jar acx.jar mkdir -d=test.dsk testdir
Not a directory: 'TESTDIR'
```

The problem is `MkdirCommand::handleCommand()` method does not filter out deleted file/directory entries.