### PR TITLE
acx - Filter out deleted file entries

### DIFF
--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/ImportCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/ImportCommand.java
@@ -92,6 +92,7 @@ public class ImportCommand extends ReadWriteDiskCommandOptions {
             for (String dir : dirs) {
                 Optional<FileEntry> fileEntry = directory.getFiles().stream()
                         .filter(f -> dir.equalsIgnoreCase(f.getFilename()))
+                        .filter(f -> !f.isDeleted())
                         .findFirst();
                 Optional<DirectoryEntry> dirEntry = fileEntry
                         .filter(FileEntry::isDirectory)

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/RmdirCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/RmdirCommand.java
@@ -54,6 +54,7 @@ public class RmdirCommand extends ReadWriteDiskCommandOptions {
             final String pathName = formattedDisk.getSuggestedFilename(paths[i]);
             Optional<FileEntry> optEntry = directory.getFiles().stream()
                     .filter(entry -> entry.getFilename().equalsIgnoreCase(pathName))
+                    .filter(entry -> !entry.isDeleted())
                     .findFirst();
             
             if (optEntry.isPresent()) {

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/fileutil/FileUtils.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/fileutil/FileUtils.java
@@ -89,6 +89,7 @@ public class FileUtils {
 	    String sanitizedName = directory.getFormattedDisk().getSuggestedFilename(sourceName);
 	    final Optional<FileEntry> fileEntry = directory.getFiles().stream()
 	        .filter(entry -> entry.getFilename().equals(sanitizedName))
+                .filter(entry -> !entry.isDeleted())
 	        .findFirst();
 
         final FileEntry targetFile;

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/fileutil/FileUtils.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/fileutil/FileUtils.java
@@ -56,6 +56,7 @@ public class FileUtils {
 	    Optional<FileEntry> targetFile = targetParent.getFiles()
 	            .stream()
 	            .filter(fileEntry -> name.equals(fileEntry.getFilename()))
+                    .filter(fileEntry -> !fileEntry.isDeleted())
 	            .findFirst();
 	    Optional<DirectoryEntry> targetDir = targetFile
 	            .filter(FileEntry::isDirectory)


### PR DESCRIPTION
Four additional patches similar to #96 are needed.  The following procedures demostrate why those patches are necessary.

1) ```RmdirCommand::handleCommand()```
```
# Remove a directory which is already removed
java -jar acx.jar create -d=test.dsk --prodos
java -jar acx.jar mkdir -d=test.dsk TESTDIR
java -jar acx.jar rmdir -d=test.dsk TESTDIR
java -jar acx.jar rmdir -d=test.dsk TESTDIR
# The program shows: Not a directory: 'TESTDIR'
# After patching, it shows: Directory does not exist: 'TESTDIR' 
```

2) ```FileUtils::copyFile()```
```
# Delete a file, then import a file with the same name
java -jar acx.jar create -d=test.dsk --prodos
echo test | java -jar acx.jar import -d=test.dsk --text --stdin -n=TESTFILE 
java -jar acx.jar delete -d=test.dsk TESTFILE
echo test | java -jar acx.jar import -d=test.dsk --text --stdin -n=TESTFILE 
# The progran shows: File 'TESTFILE' exists.
# After patching, the second import is successful.
```

3) ```FileUtils::copyDirectory()```
```
# Copy TESTDIR from source.dsk to target.dsk with -r option
# Remove TESTDIR from target.dsk
# Copy TESTDIR from source.dsk to target.dsk with -r option AGAIN
java -jar acx.jar create -d=source.dsk --prodos
java -jar acx.jar create -d=target.dsk --prodos
java -jar acx.jar mkdir -d=source.dsk TESTDIR
java -jar acx.jar copy -d=target.dsk -s=source.dsk TESTDIR -r
java -jar acx.jar rmdir -d=target.dsk TESTDIR
java -jar acx.jar copy -d=target.dsk -s=source.dsk TESTDIR -r
# The program shows: "Unable to create directory"
# After patching, the directory is copied sucessfully.
```
4) ```ImportCommand::handleCommand()```

Prepare a ProDOS image ```test.dsk``` and execute the following ProDOS commands on an emulator.
```
CREATE TESTDIR
CREATE TESTDIR2
DELETE TESTDIR
RENAME TESTDIR2,TESTDIR
```
There are two ```TESTDIR``` entries in the root directory. The first one is marked as deleted.
```
java -jar acx.jar list -d=test.dsk --deleted

File: test.dsk
Name: /NEW.DISK/
  TESTDIR         DIR      001 <NO DATE>  <NO DATE>         512          [deleted]
  TESTDIR         DIR      001 <NO DATE>  <NO DATE>         512
ProDOS format; 139,264 bytes free; 4,096 bytes used.
```
Then, import a file to ```TESTDIR``` directory.
```
echo hello|java -jar acx.jar import -d=test.dsk --text --stdin -n=TESTFILE --dir=TESTDIR
# The program shows: Directory 'TESTDIR' not found.
# After patching, the file is imported successfully.
```








