### PR TITLE
acx - Dump Command Enhancements

### DIFF
--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
@@ -52,11 +52,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
     @Override
     public int handleCommand() throws Exception {
         byte[] data = options.coordinate.read(disk);
-        if (output.raw) {
-            System.out.write(data);
-        } else {
-            System.out.println(output.format(options, data));
-        }
+        System.out.println(output.format(options, data));
         return 0;
     }
     
@@ -66,7 +62,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
             return fn.apply(options, data);
         }
         
-        @Option(names = "--hex", description = "Hex dump. (Default)")
+        @Option(names = "--hex", description = "Hex dump. (default)")
         public void selectHexDump(boolean flag) {
             fn = this::formatHexDump;
         }
@@ -75,9 +71,6 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
         public void selectDisassembly(boolean flag) {
             fn = this::formatDisassembly;
         }
-		
-        @Option(names = "--raw", description = "Raw Binary dump.")
-        public boolean raw = false;
         
         public String formatHexDump(Options options, byte[] data) {
             return AppleUtil.getHexDump(data);
@@ -141,7 +134,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
                 return this.instructionSet;
             }
 
-            @Option(names = "--6502", description = "MOS 6502. (Default)")
+            @Option(names = "--6502", description = "MOS 6502. (default)")
             public void select6502(boolean flag) {
                 this.instructionSet = InstructionSet6502.for6502();
             }

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
@@ -70,7 +70,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
         public void selectHexDump(boolean flag) {
             fn = this::formatHexDump;
         }
-		
+
         @Option(names = "--disassembly", description = "Disassembly.")
         public void selectDisassembly(boolean flag) {
             fn = this::formatDisassembly;
@@ -126,7 +126,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
         @Option(names = {"-a", "--address"}, converter = IntegerTypeConverter.class,
                          description = "Starting Address.")
         private int address = 0x800;
-		
+
         @Option(names = {"-o", "--offset"}, converter = IntegerTypeConverter.class,
                          description = "Number of bytes to skip into file before disassembling.")
         private Optional<Integer> offset = Optional.empty();

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
@@ -52,7 +52,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
     @Override
     public int handleCommand() throws Exception {
         byte[] data = options.coordinate.read(disk);
-		if (output.raw) {
+        if (output.raw) {
             System.out.write(data);
         } else {
             System.out.println(output.format(options, data));
@@ -141,7 +141,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
                 return this.instructionSet;
             }
 
-	        @Option(names = "--6502", description = "MOS 6502. (Default)")
+            @Option(names = "--6502", description = "MOS 6502. (Default)")
             public void select6502(boolean flag) {
                 this.instructionSet = InstructionSet6502.for6502();
             }

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
@@ -76,8 +76,8 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
             fn = this::formatDisassembly;
         }
 		
-		@Option(names = "--raw", description = "Raw Binary dump.")
-		public boolean raw = false;
+        @Option(names = "--raw", description = "Raw Binary dump.")
+        public boolean raw = false;
         
         public String formatHexDump(Options options, byte[] data) {
             return AppleUtil.getHexDump(data);
@@ -122,17 +122,17 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
         private DisassemblerOptions disassemblerOptions = new DisassemblerOptions();
     }
 
-	public static class DisassemblerOptions {
-		@Option(names = {"-a", "--address"}, converter = IntegerTypeConverter.class,
-		                 description = "Starting Address.")
-		private int address = 0x800;
+    public static class DisassemblerOptions {
+        @Option(names = {"-a", "--address"}, converter = IntegerTypeConverter.class,
+                         description = "Starting Address.")
+        private int address = 0x800;
 		
-		@Option(names = {"-o", "--offset"}, converter = IntegerTypeConverter.class,
-		                 description = "Number of bytes to skip into file before disassembling.")
-		private Optional<Integer> offset = Optional.empty();
+        @Option(names = {"-o", "--offset"}, converter = IntegerTypeConverter.class,
+                         description = "Number of bytes to skip into file before disassembling.")
+        private Optional<Integer> offset = Optional.empty();
 		
-	    @ArgGroup(multiplicity = "0..1")
-	    private InstructionSetSelection instructionSet = new InstructionSetSelection();
+        @ArgGroup(multiplicity = "0..1")
+        private InstructionSetSelection instructionSet = new InstructionSetSelection();
 	
         public static class InstructionSetSelection {
             private InstructionSet instructionSet = InstructionSet6502.for6502();
@@ -140,8 +140,8 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
             public InstructionSet get() {
                 return this.instructionSet;
             }
-		
-	    	@Option(names = "--6502", description = "MOS 6502. (Default)")
+
+	        @Option(names = "--6502", description = "MOS 6502. (Default)")
             public void select6502(boolean flag) {
                 this.instructionSet = InstructionSet6502.for6502();
             }
@@ -160,7 +160,7 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
             @Option(names = { "--6502S" }, description = "MOS 6502 with SWEET16 switching.")
             public void select6502Switching(boolean flag) {
                 this.instructionSet = InstructionSet6502Switching.withSwitching();
-            }			
+            }		
         }	
-	}
+    }
 }

--- a/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
+++ b/app/cli-acx/src/main/java/io/github/applecommander/acx/command/DumpCommand.java
@@ -32,13 +32,16 @@ import io.github.applecommander.acx.base.ReadOnlyDiskImageCommandOptions;
 import io.github.applecommander.acx.converter.IntegerTypeConverter;
 import io.github.applecommander.disassembler.api.Disassembler;
 import io.github.applecommander.disassembler.api.Instruction;
+import io.github.applecommander.disassembler.api.InstructionSet;
 import io.github.applecommander.disassembler.api.mos6502.InstructionSet6502;
+import io.github.applecommander.disassembler.api.sweet16.InstructionSetSWEET16;
+import io.github.applecommander.disassembler.api.switching6502.InstructionSet6502Switching;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
-@Command(name = "dump", description = "Dump a block or sector.")
+@Command(name = "dump", description = "Dump a block or sector.", sortOptions = false)
 public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
     @ArgGroup(heading = "%nOutput Selection:%n")
     private OutputSelection output = new OutputSelection();
@@ -49,7 +52,11 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
     @Override
     public int handleCommand() throws Exception {
         byte[] data = options.coordinate.read(disk);
-        System.out.println(output.format(options, data));
+		if (output.raw) {
+            System.out.write(data);
+        } else {
+            System.out.println(output.format(options, data));
+        }
         return 0;
     }
     
@@ -59,33 +66,36 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
             return fn.apply(options, data);
         }
         
-        @Option(names = "--hex", description = "Hex dump.")
+        @Option(names = "--hex", description = "Hex dump. (Default)")
         public void selectHexDump(boolean flag) {
             fn = this::formatHexDump;
         }
-        
+		
         @Option(names = "--disassembly", description = "Disassembly.")
         public void selectDisassembly(boolean flag) {
             fn = this::formatDisassembly;
         }
+		
+		@Option(names = "--raw", description = "Raw Binary dump.")
+		public boolean raw = false;
         
         public String formatHexDump(Options options, byte[] data) {
-            return AppleUtil.getHexDump(options.address, data);
+            return AppleUtil.getHexDump(data);
         }
         
         public String formatDisassembly(Options options, byte[] data) {
             // If the offset is given, use that. If not, use 0 except for the boot sector and then use 1.
-            int calculatedOffset = options.offset.orElse(options.coordinate.includesBootSector() ? 1 : 0);
+            int calculatedOffset = options.disassemblerOptions.offset.orElse(options.coordinate.includesBootSector() ? 1 : 0);
             return Disassembler.with(data)
-                    .startingAddress(options.address)
+                    .startingAddress(options.disassemblerOptions.address)
                     .bytesToSkip(calculatedOffset)
-                    .use(InstructionSet6502.for6502())
+                    .use(options.disassemblerOptions.instructionSet.get())
                     .decode()
                     .stream()
                     .map(this::formatInstruction)
                     .collect(Collectors.joining());
-
         }
+
         private String formatInstruction(Instruction instruction) {
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
@@ -106,14 +116,51 @@ public class DumpCommand extends ReadOnlyDiskImageCommandOptions {
     
     public static class Options {
         @ArgGroup(multiplicity = "1", heading = "%nCoordinate Selection:%n")
-        private CoordinateSelection coordinate = new CoordinateSelection();
-        
-        @Option(names = { "-a", "--address" }, converter = IntegerTypeConverter.class, 
-                description = "Starting address.")
-        private int address = 0x800;
-        
-        @Option(names = { "-o", "--offset" }, converter = IntegerTypeConverter.class, 
-                description = "Number of bytes to skip into file before disassembling.")
-        private Optional<Integer> offset = Optional.empty();
+        private CoordinateSelection coordinate = new CoordinateSelection();		
+		
+        @ArgGroup(heading = "%nDisassembler Options:%n", exclusive = false)
+        private DisassemblerOptions disassemblerOptions = new DisassemblerOptions();
     }
+
+	public static class DisassemblerOptions {
+		@Option(names = {"-a", "--address"}, converter = IntegerTypeConverter.class,
+		                 description = "Starting Address.")
+		private int address = 0x800;
+		
+		@Option(names = {"-o", "--offset"}, converter = IntegerTypeConverter.class,
+		                 description = "Number of bytes to skip into file before disassembling.")
+		private Optional<Integer> offset = Optional.empty();
+		
+	    @ArgGroup(multiplicity = "0..1")
+	    private InstructionSetSelection instructionSet = new InstructionSetSelection();
+	
+        public static class InstructionSetSelection {
+            private InstructionSet instructionSet = InstructionSet6502.for6502();
+        
+            public InstructionSet get() {
+                return this.instructionSet;
+            }
+		
+	    	@Option(names = "--6502", description = "MOS 6502. (Default)")
+            public void select6502(boolean flag) {
+                this.instructionSet = InstructionSet6502.for6502();
+            }
+            @Option(names = { "--65C02" }, description = "WDC 65C02.")
+            public void select65C02(boolean flag) {
+                this.instructionSet = InstructionSet6502.for65C02();
+            }
+            @Option(names = { "--6502X" }, description = "MOS 6502 + 'illegal' instructions.")
+            public void select6502X(boolean flag) {
+                this.instructionSet = InstructionSet6502.for6502withIllegalInstructions();
+            }
+            @Option(names = { "--SWEET16" }, description = "SWEET16.")
+            public void selectSWEET16(boolean flag) {
+                this.instructionSet = InstructionSetSWEET16.forSWEET16();
+            }
+            @Option(names = { "--6502S" }, description = "MOS 6502 with SWEET16 switching.")
+            public void select6502Switching(boolean flag) {
+                this.instructionSet = InstructionSet6502Switching.withSwitching();
+            }			
+        }	
+	}
 }


### PR DESCRIPTION
I have made some enhancements to the `dump` command.

1) Instruction Set selection. The disassembler, `acdasm`, already supports 6502, 6502S, 6502X, 65C02 and SWEET16 instruction sets. So, it is easy to enable those instruction sets in the disassembler.

2) For hex dump, the address is fixed at 0. I think it makes more sense to use address 0 instead of 0x800.

```
Offset   Hex Data                                          Characters
=======  ================================================  =================
$000000  01 38 B0 03 4C 32 A1 86  43 C9 03 08 8A 29 70 4A  .80.L2!. CI...)pJ
$000010  4A 4A 4A 09 C0 85 49 A0  FF 84 48 28 C8 B1 48 D0  JJJ.@.I  ..H(H1HP
$000020  3A B0 0E A9 03 8D 00 08  E6 3D A5 49 48 A9 5B 48  :0.).... f=%IH)[H
$000030  60 85 40 85 48 A0 63 B1  48 99 94 09 C8 C0 EB D0  `.@.H c1 H...H@kP
$000040  F6 A2 06 BC 1D 09 BD 24  09 99 F2 09 BD 2B 09 9D  v".<..=$ ..r.=+..
$000050  7F 0A CA 10 EE A9 09 85  49 A9 86 A0 00 C9 F9 B0  ..J.n).. I). .Iy0
$000060  2F 85 48 84 60 84 4A 84  4C 84 4E 84 47 C8 84 42  /.H.`.J. L.N.GH.B
```

3) Revamp the help message
```
Usage: acx dump [-h] -d=<disk> [--disassembly | --hex] ([-t=<track>
                -s=<sector>] | [[-b=<block>]]) [[-a=<address>] [-o=<offset>]
                [--6502S | --6502 | --65C02 | --6502X | --SWEET16]]

Dump a block or sector.

Options:
  -h, --help                Show help for subcommand.
  -d, --disk=<disk>         Image to process [$ACX_DISK_NAME].

Output Selection:
      --disassembly         Disassembly.
      --hex                 Hex dump. (default)

Coordinate Selection:
  -t, --track=<track>       Track number.
  -s, --sector=<sector>     Sector number.
  -b, --block=<block>       Block number.

Disassembler Options:
  -a, --address=<address>   Starting Address.
  -o, --offset=<offset>     Number of bytes to skip into file before
                              disassembling.
      --6502                MOS 6502. (default)
      --65C02               WDC 65C02.
      --6502X               MOS 6502 + 'illegal' instructions.
      --SWEET16             SWEET16.
      --6502S               MOS 6502 with SWEET16 switching.
```

