### PR TITLE
Restrict UPX action to Linux only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
           GRADLE_OPTS: -Djava.io.tmpdir=${{ runner.temp }}
       - name: Run UPX
         uses: crazy-max/ghaction-upx@v4
-        if: runner.os == 'Windows' || runner.os == 'Linux'
+        if: runner.os == 'Linux'
         with:
           files: |
             app/cli-ac/build/native/nativeCompile/ac-*


### PR DESCRIPTION
Update UPX action to run only on Linux. Hypothetically, UPX itself can be seen as a problem. This is an experiment.